### PR TITLE
Gets rpcuser and rpcpassword from BitcoinDark.conf

### DIFF
--- a/btcdapi.js
+++ b/btcdapi.js
@@ -1,5 +1,34 @@
+fs = require('fs.extra')
+
+if (process.platform == 'darwin') { //If Mac OS X
+    filepath = process.env.HOME + '/Library/Application Support/BitcoinDark/BitcoinDark.conf';
+} else if (process.platform == 'linux') { //If Linux
+    filepath = process.env.HOME + '/.BitcoinDark/BitcoinDark.conf';
+} else { //Else it's Windows
+    filepath = process.env.APPDATA + '/BitcoinDark/BitcoinDark.conf';
+}
+
+if (fs.existsSync(filepath) == false) { console.log('Conf file does not exists. Copying default conf file...');
+fs.copy('btcd/BitcoinDark.conf', filepath, { replace: false }, function (err) {
+  if (err) {
+    throw err;
+  }
+  console.log('Copied btcd/BitcoinDark.conf to ' + filepath);
+});
+}
+
+conf_data = fs.readFileSync(filepath, 'utf8', function (err,data) {
+  if (err) {
+    return console.log(err);
+  }
+});
+
+arrayFromConf = conf_data.match(/[^\r\n]+/g); //Turn all lines to an array
+var rpcuser = arrayFromConf['0'].substring(arrayFromConf['0'].indexOf("=") + 1); //Only get specific line, and get value after '='
+var rpcpass = arrayFromConf['1'].substring(arrayFromConf['1'].indexOf("=") + 1); //Only get specific line, and get value after '='
+
 var btcd = require('node-btcd')();
-btcd.auth('rpcuser', 'rpcpass');
+btcd.auth(rpcuser, rpcpass);
 
 module.exports = btcd;
 


### PR DESCRIPTION
Updated code to get rpcuser and rpcpassword values from the default locations of BitcoinDark.conf file on different platform.

The updated code also require fs.extra npm package.